### PR TITLE
SLING-7169 consolidate configuration to DefaultGetServlet

### DIFF
--- a/src/main/java/org/apache/sling/servlets/get/impl/DefaultGetServlet.java
+++ b/src/main/java/org/apache/sling/servlets/get/impl/DefaultGetServlet.java
@@ -133,8 +133,6 @@ public class DefaultGetServlet extends SlingSafeMethodsServlet {
 
     private Map<String, Servlet> rendererMap = new HashMap<>();
 
-    private Servlet streamerServlet;
-
     private int jsonMaximumResults;
 
     /** Additional aliases. */
@@ -156,6 +154,16 @@ public class DefaultGetServlet extends SlingSafeMethodsServlet {
 
     @Reference(policyOption = ReferencePolicyOption.GREEDY)
     private XSSAPI xssApi;
+    
+    public static final String EXT_HTML = "html";
+
+    public static final String EXT_TXT = "txt";
+
+    public static final String EXT_JSON = "json";
+
+    public static final String EXT_XML = "xml";
+
+    public static final String EXT_RES = "res";
 
     @Activate
     protected void activate(Config cfg) {
@@ -182,15 +190,15 @@ public class DefaultGetServlet extends SlingSafeMethodsServlet {
 
     private Servlet getDefaultRendererServlet(final String type) {
         Servlet servlet = null;
-        if ( StreamRendererServlet.EXT_RES.equals(type) ) {
+        if ( EXT_RES.equals(type) ) {
             servlet = new StreamRendererServlet(index, indexFiles);
-        } else if ( HtmlRendererServlet.EXT_HTML.equals(type) ) {
+        } else if ( EXT_HTML.equals(type) ) {
             servlet = new HtmlRendererServlet(xssApi);
-        } else if ( PlainTextRendererServlet.EXT_TXT.equals(type) ) {
+        } else if ( EXT_TXT.equals(type) ) {
             servlet = new PlainTextRendererServlet();
-        } else if (JsonRendererServlet.EXT_JSON.equals(type) ) {
+        } else if (EXT_JSON.equals(type) ) {
             servlet = new JsonRendererServlet(jsonMaximumResults);
-        } else if ( XMLRendererServlet.EXT_XML.equals(type) ) {
+        } else if ( EXT_XML.equals(type) ) {
             try {
                 servlet = new XMLRendererServlet();
             } catch (Throwable t) {
@@ -215,29 +223,30 @@ public class DefaultGetServlet extends SlingSafeMethodsServlet {
 
         // use the servlet for rendering StreamRendererServlet.EXT_RES as the
         // streamer servlet
-        streamerServlet = getDefaultRendererServlet(StreamRendererServlet.EXT_RES);
+        Servlet streamerServlet = getDefaultRendererServlet(EXT_RES);
 
-        // Register renderer servlets
-        rendererMap.put(StreamRendererServlet.EXT_RES, streamerServlet);
-
+        rendererMap.put(null, streamerServlet);
+        
+        rendererMap.put(EXT_RES, streamerServlet);
+        
         if (enableHtml) {
-            rendererMap.put(HtmlRendererServlet.EXT_HTML,
-                    getDefaultRendererServlet(HtmlRendererServlet.EXT_HTML));
+            rendererMap.put(EXT_HTML,
+                    getDefaultRendererServlet(EXT_HTML));
         }
 
         if (enableTxt) {
-            rendererMap.put(PlainTextRendererServlet.EXT_TXT,
-                    getDefaultRendererServlet(PlainTextRendererServlet.EXT_TXT));
+            rendererMap.put(EXT_TXT,
+                    getDefaultRendererServlet(EXT_TXT));
         }
 
         if (enableJson) {
-            rendererMap.put(JsonRendererServlet.EXT_JSON,
-                    getDefaultRendererServlet(JsonRendererServlet.EXT_JSON));
+            rendererMap.put(EXT_JSON,
+                    getDefaultRendererServlet(EXT_JSON));
         }
 
         if (enableXml) {
-            rendererMap.put(XMLRendererServlet.EXT_XML,
-                    getDefaultRendererServlet(XMLRendererServlet.EXT_XML));
+            rendererMap.put(EXT_XML,
+                    getDefaultRendererServlet(EXT_XML));
         }
 
 
@@ -284,11 +293,7 @@ public class DefaultGetServlet extends SlingSafeMethodsServlet {
 
         Servlet rendererServlet;
         String ext = request.getRequestPathInfo().getExtension();
-        if (ext == null) {
-            rendererServlet = streamerServlet;
-        } else {
-            rendererServlet = rendererMap.get(ext);
-        }
+        rendererServlet = rendererMap.get(ext);
 
         // fail if we should not just stream or we cannot support the ext.
         if (rendererServlet == null) {
@@ -334,7 +339,6 @@ public class DefaultGetServlet extends SlingSafeMethodsServlet {
             }
         }
 
-        streamerServlet = null;
         rendererMap.clear();
 
         super.destroy();

--- a/src/main/java/org/apache/sling/servlets/get/impl/helpers/HtmlRendererServlet.java
+++ b/src/main/java/org/apache/sling/servlets/get/impl/helpers/HtmlRendererServlet.java
@@ -40,7 +40,7 @@ public class HtmlRendererServlet extends SlingSafeMethodsServlet {
 
     private static final long serialVersionUID = -5815904221043005085L;
 
-    public static final String EXT_HTML = "html";
+
 
     private final XSSAPI xssApi;
 

--- a/src/main/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererServlet.java
+++ b/src/main/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererServlet.java
@@ -46,8 +46,6 @@ public class JsonRendererServlet extends SlingSafeMethodsServlet {
 
     private static final long serialVersionUID = 5577121546674133317L;
 
-    public static final String EXT_JSON = "json";
-
     /** Recursion level selector that means "all levels" */
     public static final String INFINITY = "infinity";
 

--- a/src/main/java/org/apache/sling/servlets/get/impl/helpers/PlainTextRendererServlet.java
+++ b/src/main/java/org/apache/sling/servlets/get/impl/helpers/PlainTextRendererServlet.java
@@ -40,8 +40,6 @@ public class PlainTextRendererServlet extends SlingSafeMethodsServlet {
 
     private static final long serialVersionUID = -5815904221043005085L;
 
-    public static final String EXT_TXT = "txt";
-
     @Override
     protected void doGet(SlingHttpServletRequest req,
             SlingHttpServletResponse resp) throws ServletException, IOException {

--- a/src/main/java/org/apache/sling/servlets/get/impl/helpers/StreamRendererServlet.java
+++ b/src/main/java/org/apache/sling/servlets/get/impl/helpers/StreamRendererServlet.java
@@ -51,6 +51,7 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.resource.external.ExternalizableInputStream;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.servlets.get.impl.DefaultGetServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,8 +63,6 @@ import org.slf4j.LoggerFactory;
  * {@link PlainTextRendererServlet}.
  */
 public class StreamRendererServlet extends SlingSafeMethodsServlet {
-
-    public static final String EXT_RES = "res";
 
     private static final long serialVersionUID = -1L;
 
@@ -125,7 +124,7 @@ public class StreamRendererServlet extends SlingSafeMethodsServlet {
 
         // ensure no extension or "res"
         String ext = request.getRequestPathInfo().getExtension();
-        if (ext != null && !ext.equals(EXT_RES)) {
+        if (ext != null && !ext.equals(DefaultGetServlet.EXT_RES)) {
             request.getRequestProgressTracker().log(
                 "StreamRendererServlet does not support for extension " + ext);
             if (included || response.isCommitted()) {

--- a/src/main/java/org/apache/sling/servlets/get/impl/helpers/XMLRendererServlet.java
+++ b/src/main/java/org/apache/sling/servlets/get/impl/helpers/XMLRendererServlet.java
@@ -43,8 +43,6 @@ public class XMLRendererServlet extends SlingSafeMethodsServlet {
 
     private static final long serialVersionUID = -3520278283206430415L;
 
-    public static final String EXT_XML = "xml";
-
     private static final String SYSVIEW = "sysview";
     private static final String DOCVIEW = "docview";
 

--- a/src/test/java/org/apache/sling/servlets/get/impl/DefaultGetServletTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/DefaultGetServletTest.java
@@ -48,10 +48,11 @@ public class DefaultGetServletTest {
 
         @SuppressWarnings("unchecked")
         final Map<String, Servlet> map = (Map<String, Servlet>) field.get(servlet);
-        assertEquals(4, map.size());
-        assertNotNull(map.get("res"));
-        assertNotNull(map.get("html"));
-        assertNotNull(map.get("json"));
+        assertEquals(5, map.size());
+        assertNotNull(map.get(DefaultGetServlet.EXT_RES));
+        assertNotNull(map.get(DefaultGetServlet.EXT_HTML));
+        assertNotNull(map.get(DefaultGetServlet.EXT_JSON));
         assertNotNull(map.get("pdf"));
+        assertNotNull(map.get(null));
     }
 }


### PR DESCRIPTION
RedirectServlet now passes the handling of a .json request to to the
DefaultGetServlet. Moved the definitions of extensions to
the DefaultGetServlet as this the primary location of use.