### PR TITLE
SLING-11727 Fixed Flaky Tests

### DIFF
--- a/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
@@ -184,11 +184,16 @@ public class JsonRendererTest {
     public void testBooleansNoTidy() throws IOException {
         context.currentResource("/content/booleans");
         final String expected = "{\"b2\":false,\"jcr:primaryType\":\"nt:unstructured\",\"s1\":\"true\",\"b1\":true,\"s2\":\"false\"}";
-        JsonReader jsonReader = Json.createReader(new StringReader(expected));
-        JsonObject expectedObject = jsonReader.readObject();
-        jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
-        JsonObject targetObject = jsonReader.readObject();
-        JsonPatch diff = Json.createDiff(expectedObject, targetObject);
+        JsonPatch diff;
+        try{
+            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonObject expectedObject = jsonReader.readObject();
+            jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
+            JsonObject targetObject = jsonReader.readObject();
+            diff = Json.createDiff(expectedObject, targetObject);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         assertEquals("[]", diff.toString());
     }
 
@@ -204,11 +209,16 @@ public class JsonRendererTest {
             "  \"b1\": true,\n" +
             "  \"s2\": \"false\"\n" +
             "  }";
-        JsonReader jsonReader = Json.createReader(new StringReader(expected));
-        JsonObject expectedObject = jsonReader.readObject();
-        jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
-        JsonObject targetObject = jsonReader.readObject();
-        JsonPatch diff = Json.createDiff(expectedObject, targetObject);
+        JsonPatch diff;
+        try{
+            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonObject expectedObject = jsonReader.readObject();
+            jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
+            JsonObject targetObject = jsonReader.readObject();
+            diff = Json.createDiff(expectedObject, targetObject);
+        } catch (IOException e) {
+            throw new RuntimeExsception(e);
+        }
         assertEquals("[]", diff.toString());
     }
 

--- a/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
@@ -185,14 +185,12 @@ public class JsonRendererTest {
         context.currentResource("/content/booleans");
         final String expected = "{\"b2\":false,\"jcr:primaryType\":\"nt:unstructured\",\"s1\":\"true\",\"b1\":true,\"s2\":\"false\"}";
         JsonPatch diff;
-        try{
-            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+        try(JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonReader jsonReader1 = Json.createReader(new StringReader(getJsonFromRequestResponse()));
+        ){
             JsonObject expectedObject = jsonReader.readObject();
-            jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
-            JsonObject targetObject = jsonReader.readObject();
+            JsonObject targetObject = jsonReader1.readObject();
             diff = Json.createDiff(expectedObject, targetObject);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
         assertEquals("[]", diff.toString());
     }
@@ -210,14 +208,12 @@ public class JsonRendererTest {
             "  \"s2\": \"false\"\n" +
             "  }";
         JsonPatch diff;
-        try{
-            JsonReader jsonReader = Json.createReader(new StringReader(expected));
+        try(JsonReader jsonReader = Json.createReader(new StringReader(expected));
+            JsonReader jsonReader1 = Json.createReader(new StringReader(getJsonFromRequestResponse()));
+        ){
             JsonObject expectedObject = jsonReader.readObject();
-            jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
-            JsonObject targetObject = jsonReader.readObject();
+            JsonObject targetObject = jsonReader1.readObject();
             diff = Json.createDiff(expectedObject, targetObject);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
         assertEquals("[]", diff.toString());
     }

--- a/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
@@ -217,7 +217,7 @@ public class JsonRendererTest {
             JsonObject targetObject = jsonReader.readObject();
             diff = Json.createDiff(expectedObject, targetObject);
         } catch (IOException e) {
-            throw new RuntimeExsception(e);
+            throw new RuntimeException(e);
         }
         assertEquals("[]", diff.toString());
     }

--- a/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
@@ -36,6 +36,7 @@ import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class JsonRendererTest {
 
@@ -182,7 +183,7 @@ public class JsonRendererTest {
     public void testBooleansNoTidy() throws IOException {
         context.currentResource("/content/booleans");
         final String expected = "{\"b2\":false,\"jcr:primaryType\":\"nt:unstructured\",\"s1\":\"true\",\"b1\":true,\"s2\":\"false\"}";
-        assertEquals(expected, getJsonFromRequestResponse());
+        JSONAssert.assertEquals(expected, getJsonFromRequestResponse());
     }
 
     @Test
@@ -197,7 +198,7 @@ public class JsonRendererTest {
             "  \"b1\": true,\n" +
             "  \"s2\": \"false\"\n" +
             "  }";
-        assertEquals(expected, getJsonFromRequestResponse());
+        JSONAssert.assertEquals(expected, getJsonFromRequestResponse());
     }
 
     private JsonObject getJsonFromReader() throws IOException {

--- a/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
@@ -26,8 +26,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Calendar;
 
-import javax.json.Json;
-import javax.json.JsonObject;
+import javax.json.*;
 
 import org.apache.jackrabbit.util.ISO8601;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
@@ -183,7 +182,12 @@ public class JsonRendererTest {
     public void testBooleansNoTidy() throws IOException {
         context.currentResource("/content/booleans");
         final String expected = "{\"b2\":false,\"jcr:primaryType\":\"nt:unstructured\",\"s1\":\"true\",\"b1\":true,\"s2\":\"false\"}";
-        JSONAssert.assertEquals(expected, getJsonFromRequestResponse());
+        JsonReader jsonReader = Json.createReader(new StringReader(expected));
+        JsonObject expectedObject = jsonReader.readObject();
+        jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
+        JsonObject targetObject = jsonReader.readObject();
+        JsonPatch diff = Json.createDiff(expectedObject, targetObject);
+        assertEquals("[]", diff.toString());
     }
 
     @Test
@@ -198,7 +202,12 @@ public class JsonRendererTest {
             "  \"b1\": true,\n" +
             "  \"s2\": \"false\"\n" +
             "  }";
-        JSONAssert.assertEquals(expected, getJsonFromRequestResponse());
+        JsonReader jsonReader = Json.createReader(new StringReader(expected));
+        JsonObject expectedObject = jsonReader.readObject();
+        jsonReader = Json.createReader(new StringReader(getJsonFromRequestResponse()));
+        JsonObject targetObject = jsonReader.readObject();
+        JsonPatch diff = Json.createDiff(expectedObject, targetObject);
+        assertEquals("[]", diff.toString());
     }
 
     private JsonObject getJsonFromReader() throws IOException {

--- a/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
+++ b/src/test/java/org/apache/sling/servlets/get/impl/helpers/JsonRendererTest.java
@@ -26,7 +26,10 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Calendar;
 
-import javax.json.*;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonPatch;
+import javax.json.JsonReader;
 
 import org.apache.jackrabbit.util.ISO8601;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
@@ -35,7 +38,6 @@ import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class JsonRendererTest {
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

The tests JsonRendererTest#testBooleansNoTidy and JsonRendererTest#testBooleansNoTidy#testBooleansWithTidy  express non-deterministic behaviour and change the order of the attributes. The fix is adding the JSONAssert to check whether the json objects are equal to ensure determinism.

Motivation
Fixing non-deterministic flaky tests.
