### PR TITLE
SLING-11897 - Default Get Servlet tests fail on Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>41</version>
+        <version>48</version>
         <relativePath />
     </parent>
 
@@ -45,6 +45,7 @@
 
     <properties>
         <site.jira.version.id>12314473</site.jira.version.id>
+        <project.build.outputTimestamp>1</project.build.outputTimestamp>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+            <scope>test</scope>
+            <version>3.1.10-1.44.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
             <version>3.0.2</version>
             <scope>test</scope>
@@ -187,12 +193,6 @@
           <version>2.8.0</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-            <scope>test</scope>
-            <version>2.1.10-1.16.0</version>
-          </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.servlet-helpers</artifactId>


### PR DESCRIPTION
- update to a more recent version of sling-mock-oak
- ensure that it is on the classpath before sling-mock.junit4, so that the Oak dependency is not overridden