### PR TITLE
chore(deps): bump sling-bundle-parent from 62 to 66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Updates the Maven parent POM version for `sling-bundle-parent` to pick up the latest Sling bundle parent improvements and dependency updates.

- Bumped `sling-bundle-parent` version from `62` to `66` in `pom.xml`

Co-authored-by: Maia <maia@noreply>